### PR TITLE
feat: add optional json report to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
       The Go import path of the tested repository to add as a prefix to all paths of the
       changed files. This is useful to map the changed files (e.g., ["foo/my_file.go"]
       to their coverage profile which uses the full package name to identify the files
-      (e.g., "github.com/fgrosse/example/foo/my_file.go"). Note that currently, 
+      (e.g., "github.com/fgrosse/example/foo/my_file.go"). Note that currently,
       packages with a different name than their directory are not supported.
     required: false
     default: "github.com/${{ github.repository }}"
@@ -55,10 +55,18 @@ inputs:
     default: ${{ github.workflow_ref }}
     required: false
 
+  generate-json-report:
+    description: 'Generate a JSON report in addition to the Markdown report.'
+    required: false
+    default: 'false'
+
 outputs:
   coverage_report:
     description: 'The generated coverage report in Markdown format.'
     value: ${{ steps.coverage.outputs.coverage_report }}
+  coverage_report_json:
+    description: 'The generated coverage report in JSON format.'
+    value: ${{ steps.coverage.outputs.coverage_report_json }}
 
 runs:
   using: "composite"
@@ -98,3 +106,4 @@ runs:
         ROOT_PACKAGE: ${{ inputs.root-package }}
         SKIP_COMMENT: ${{ inputs.skip-comment }}
         TRIM_PACKAGE: ${{ inputs.trim }}
+        GENERATE_JSON_REPORT: ${{ inputs.generate-json-report }}

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -33,6 +33,7 @@ You can use the following environment variables to configure the script:
 - ROOT_PACKAGE: The import path of the tested repository to add as a prefix to all paths of the changed files (optional)
 - TRIM_PACKAGE: Trim a prefix in the \"Impacted Packages\" column of the markdown report (optional)
 - SKIP_COMMENT: Skip creating or updating the pull request comment (default: false)
+- GENERATE_JSON_REPORT: Generate JSON format report in addition to Markdown format (default: false)
 "
 
 if [[ $# != 3 ]]; then
@@ -52,8 +53,10 @@ COVERAGE_FILE_NAME=${COVERAGE_FILE_NAME:-coverage.txt}
 OLD_COVERAGE_PATH=.github/outputs/old-coverage.txt
 NEW_COVERAGE_PATH=.github/outputs/new-coverage.txt
 COVERAGE_COMMENT_PATH=.github/outputs/coverage-comment.md
+COVERAGE_JSON_PATH=.github/outputs/coverage-report.json
 CHANGED_FILES_PATH=${CHANGED_FILES_PATH:-.github/outputs/all_modified_files.json}
 SKIP_COMMENT=${SKIP_COMMENT:-false}
+GENERATE_JSON_REPORT=${GENERATE_JSON_REPORT:-false}
 
 if [[ -z ${GITHUB_REPOSITORY+x} ]]; then
     echo "Missing github_repository argument"
@@ -132,6 +135,35 @@ echo "Writing GitHub output parameter to \"$GITHUB_OUTPUT\""
   cat "$COVERAGE_COMMENT_PATH"
   echo "END_OF_COVERAGE_REPORT"
 } >> "$GITHUB_OUTPUT"
+
+if [ "$GENERATE_JSON_REPORT" = "true" ]; then
+
+  start_group "Generate JSON format report"
+  go-coverage-report \
+      -root="$ROOT_PACKAGE" \
+      -trim="$TRIM_PACKAGE" \
+      -format=json \
+      "$OLD_COVERAGE_PATH" \
+      "$NEW_COVERAGE_PATH" \
+      "$CHANGED_FILES_PATH" \
+    > $COVERAGE_JSON_PATH
+  end_group
+
+  if [ ! -s $COVERAGE_JSON_PATH ]; then
+    echo "::notice::No JSON coverage report to output"
+    exit 0
+  fi
+
+  # Output the coverage report as a multiline GitHub output parameter
+  echo "Writing JSON report GitHub output parameter to \"$GITHUB_OUTPUT\""
+  {
+    echo ""
+    echo "coverage_report_json<<END_OF_COVERAGE_REPORT_JSON"
+    cat "$COVERAGE_JSON_PATH"
+    echo "END_OF_COVERAGE_REPORT_JSON"
+  } >> "$GITHUB_OUTPUT"
+
+fi
 
 if [ "$SKIP_COMMENT" = "true" ]; then
   echo "Skipping pull request comment (\$SKIP_COMMENT=true))"


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

Add optional action output for json format code coverage report. The default report is markdown formatted for use as a PR comment. JSON format is useful for evaluating in a commit status check.

## This is how I decided to implement/fix it

## What does this change affect? (What can this break?)
Describe the critical path(s) affected as well as the related component and system functions.

## How has this been tested

## How is this change observable?

### How will this change be monitored
